### PR TITLE
Fix detection of two AVX512 features

### DIFF
--- a/src/x86/cpu_x86.cpp
+++ b/src/x86/cpu_x86.cpp
@@ -157,8 +157,8 @@ void cpu_x86::detect_host(){
         HW_AVX512_VBMI  = (info[2] & ((int)1 <<  1)) != 0;
 
         HW_AVX512_VPOPCNTDQ = (info[2] & ((int)1 << 14)) != 0;
-        HW_AVX512_4FMAPS    = (info[3] & ((int)1 <<  2)) != 0;
-        HW_AVX512_4VNNIW    = (info[3] & ((int)1 <<  3)) != 0;
+        HW_AVX512_4VNNIW    = (info[3] & ((int)1 <<  2)) != 0;
+        HW_AVX512_4FMAPS    = (info[3] & ((int)1 <<  3)) != 0;
 
         HW_AVX512_VNNI      = (info[2] & ((int)1 << 11)) != 0;
 
@@ -244,8 +244,8 @@ void cpu_x86::print() const{
     print("    AVX512-IFMA      = ", HW_AVX512_IFMA);
     print("    AVX512-VBMI      = ", HW_AVX512_VBMI);
     print("    AVX512-VPOPCNTDQ = ", HW_AVX512_VPOPCNTDQ);
-    print("    AVX512-4FMAPS    = ", HW_AVX512_4FMAPS);
     print("    AVX512-4VNNIW    = ", HW_AVX512_4VNNIW);
+    print("    AVX512-4FMAPS    = ", HW_AVX512_4FMAPS);
     print("    AVX512-VBMI2     = ", HW_AVX512_VBMI2);
     print("    AVX512-VPCLMUL   = ", HW_AVX512_VPCLMUL);
     print("    AVX512-VNNI      = ", HW_AVX512_VNNI);

--- a/src/x86/cpu_x86.h
+++ b/src/x86/cpu_x86.h
@@ -82,8 +82,8 @@ struct cpu_x86{
 
     //  Knights Mill
     bool HW_AVX512_VPOPCNTDQ;
-    bool HW_AVX512_4FMAPS;
     bool HW_AVX512_4VNNIW;
+    bool HW_AVX512_4FMAPS;
 
     //  Cascade Lake
     bool HW_AVX512_VNNI;


### PR DESCRIPTION
Noticed that these two shifts were swapped. See https://github.com/torvalds/linux/blob/master/tools/arch/x86/include/asm/cpufeatures.h#L396-L397 and https://en.wikipedia.org/wiki/CPUID#EAX=7,_ECX=0:_Extended_Features 